### PR TITLE
Tiny cleanup of build settings.

### DIFF
--- a/Trik-Observable/Trik.Observable.fsproj
+++ b/Trik-Observable/Trik.Observable.fsproj
@@ -13,6 +13,7 @@
     <Name>Trik.Observable</Name>
     <ProductVersion>12.0.0</ProductVersion>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
+    <UseMSBuildEngine>False</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Seems to build succesfully (with 1 warning) with VS2013 & XS 4.2.3
